### PR TITLE
Fix version of fairly to 0.4.1

### DIFF
--- a/jupyter_fairly/pyproject.toml
+++ b/jupyter_fairly/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
     "jupyter_server>=1.21,<3",
     "jupyterlab>=3.6.1,<4",
-    "fairly>=0.4.1",
+    "fairly==0.4.1",
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
The newest version of fairly does not work fully with this version of the extension.
The follow issues are known so far:

- Not all metadata is transfer to Zenodo when uploading a dataset (e.g. author)
- Pushing updates fail